### PR TITLE
Patch 1: Cleaner async handling in tests, and some new tests

### DIFF
--- a/src/components/shared/AddRemoveForm.js
+++ b/src/components/shared/AddRemoveForm.js
@@ -71,7 +71,7 @@ class AddRemoveForm extends React.Component {
     })
 
     if (!availableFilteredItems.length) {
-      return <em>No {recentOnly && `Recent`} Matches</em>
+      return <em data-test="none-available-message">No {recentOnly && `Recent`} Matches</em>
     }
 
     return availableFilteredItems.map(item => {


### PR DESCRIPTION
## What it be?

This is a patch on top of #1. It should be merged into that branch before being merged into master.

In this branch we are working on cleaning up the async issues in our tests, previously forcing us to use `setTimeout()`. 

See comments inline.